### PR TITLE
Add files via upload

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,0 +1,34 @@
+-- Warhammer 40K: Imperium Arsenal
+-- data-final-fixes.lua - Runs after all other mods have loaded
+
+-- DISABLE VANILLA TECHNOLOGIES
+-- This section hides all vanilla technologies while keeping our mod's tech tree visible
+
+-- List of technologies from our mod that should remain visible
+local imperium_techs = {
+  "stc-fragments",
+  "adept-armaments",
+  "tech-priest-arsenal",
+  "forge-world-relics",
+  "omnissian-sanctum"
+}
+
+-- Create a set for faster lookup
+local imperium_techs_set = {}
+for _, tech_name in pairs(imperium_techs) do
+  imperium_techs_set[tech_name] = true
+end
+
+-- Hide all vanilla technologies
+for tech_name, tech in pairs(data.raw["technology"]) do
+  -- Check if this is one of our technologies
+  if imperium_techs_set[tech_name] then
+    -- Keep our mod's technologies visible
+  else
+    -- Hide vanilla techs (but don't disable them yet)
+    tech.hidden = true
+  end
+end
+
+-- Print debug message to confirm this file is running
+log("Warhammer 40K: Imperium Arsenal - Vanilla technologies hidden")

--- a/data-update.lua
+++ b/data-update.lua
@@ -1,0 +1,23 @@
+-- Warhammer 40K: Imperium Arsenal
+-- data-updates.lua - Runs after all data.lua files are loaded but before data-final-fixes.lua
+
+-- This is a good place to add any modifications to existing data
+-- Here we prepare our mod to work alongside vanilla content but with our tech tree focus
+
+log("Warhammer 40K: Imperium Arsenal - Updates loaded")
+
+-- Ensure our technologies don't require vanilla technologies if we want a standalone experience
+-- For now, we'll keep these prerequisites to maintain compatibility
+-- We can remove these later when we implement full tech tree replacement
+
+-- Example of how we could adjust prerequisites:
+--[[
+if data.raw.technology["stc-fragments"] then
+  data.raw.technology["stc-fragments"].prerequisites = {}
+end
+
+if data.raw.technology["adept-armaments"] then
+  -- Keep our mod tech as prerequisite but remove vanilla dependencies
+  data.raw.technology["adept-armaments"].prerequisites = {"stc-fragments"}
+end
+--]]


### PR DESCRIPTION
# Pull Request: Hide Vanilla Tech Tree

## Description
This PR hides the vanilla Factorio technology tree while keeping the Warhammer 40K tech tree visible, creating a more immersive Warhammer 40K experience. This is the first step toward a full replacement of the vanilla tech tree.

## Changes

### New Files Added:

#### 1. `data-updates.lua`
```lua
-- Warhammer 40K: Imperium Arsenal
-- data-updates.lua - Runs after all data.lua files are loaded but before data-final-fixes.lua

-- This is a good place to add any modifications to existing data
-- Here we prepare our mod to work alongside vanilla content but with our tech tree focus

log("Warhammer 40K: Imperium Arsenal - Updates loaded")

-- Ensure our technologies don't require vanilla technologies if we want a standalone experience
-- For now, we'll keep these prerequisites to maintain compatibility
-- We can remove these later when we implement full tech tree replacement

-- Example of how we could adjust prerequisites:
--[[
if data.raw.technology["stc-fragments"] then
  data.raw.technology["stc-fragments"].prerequisites = {}
end

if data.raw.technology["adept-armaments"] then
  -- Keep our mod tech as prerequisite but remove vanilla dependencies
  data.raw.technology["adept-armaments"].prerequisites = {"stc-fragments"}
end
--]]
```

#### 2. `data-final-fixes.lua`
```lua
-- Warhammer 40K: Imperium Arsenal
-- data-final-fixes.lua - Runs after all other mods have loaded

-- DISABLE VANILLA TECHNOLOGIES
-- This section hides all vanilla technologies while keeping our mod's tech tree visible

-- List of technologies from our mod that should remain visible
local imperium_techs = {
  "stc-fragments",
  "adept-armaments",
  "tech-priest-arsenal",
  "forge-world-relics",
  "omnissian-sanctum"
}

-- Create a set for faster lookup
local imperium_techs_set = {}
for _, tech_name in pairs(imperium_techs) do
  imperium_techs_set[tech_name] = true
end

-- Hide all vanilla technologies
for tech_name, tech in pairs(data.raw["technology"]) do
  -- Check if this is one of our technologies
  if imperium_techs_set[tech_name] then
    -- Keep our mod's technologies visible
  else
    -- Hide vanilla techs (but don't disable them yet)
    tech.hidden = true
  end
end

-- Print debug message to confirm this file is running
log("Warhammer 40K: Imperium Arsenal - Vanilla technologies hidden")
```

### No modifications to existing files

## Testing
1. Start a new game with the mod enabled
2. Open the research screen
3. Verify that only the Warhammer 40K technologies are visible
4. Verify that the game still functions properly (you can still build essential buildings, etc.)

## Future Work
1. Replace vanilla prerequisites in our technology tree with our own technologies
2. Create replacement technologies for essential game functions
3. Adjust recipes and unlocks to maintain game playability